### PR TITLE
vcs: fix detection of git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Fixed
 - filter: Don't ignore single test argument (#97)
 - test: Update default test reference (#98)
+- vcs: fix detection of git repository
 
 ---
 

--- a/crates/tytanic-core/src/project/vcs.rs
+++ b/crates/tytanic-core/src/project/vcs.rs
@@ -58,7 +58,7 @@ impl Vcs {
 
     /// Checks the given directory for a Vcs, returning it a vcs is rooted here.
     pub fn try_new(root: &Path) -> io::Result<Option<Self>> {
-        if root.join(".git").try_exists()? && root.join(".jj").try_exists()? {
+        if root.join(".git").try_exists()? || root.join(".jj").try_exists()? {
             Ok(Some(Self::new(root, Kind::Git)))
         } else if root.join(".hg").try_exists()? {
             Ok(Some(Self::new(root, Kind::Mercurial)))


### PR DESCRIPTION
(note that I'm not familiar with jj)

A git repo only requires `.git`. I assume that jj likewise requires only `.jj`, so the two should be connected by a logical or.