### PR TITLE
docs: fix some typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - filter: Don't ignore single test argument (#97)
 - test: Update default test reference (#98)
 - vcs: fix detection of git repository
+- docs: fix some typos
 
 ---
 

--- a/docs/book/src/guides/ci.md
+++ b/docs/book/src/guides/ci.md
@@ -1,6 +1,6 @@
 # Setting Up CI
 Continuous integration can take a lot of manual work off of your shoulders.
-In this chapter we'll look at how to run `tytanic` in your GitHub CI to continuously to test your code and catch bugs before they get merged into your project.
+In this chapter we'll look at how to run `tytanic` in your GitHub CI to continuously test your code and catch bugs before they get merged into your project.
 
 <div class="warning">
 

--- a/docs/book/src/guides/test-sets.md
+++ b/docs/book/src/guides/test-sets.md
@@ -3,7 +3,7 @@
 Many operations such as running, comparing, removing or updating tests all need to somehow select which tests to operate on.
 `tytanic` offers a functional set-based language which is used to select tests, it visually resembles writing a predicate which is applied to each test.
 
-Test set expresisons are passed using the `--expression` or `-e` flag, they support the following features:
+Test set expressions are passed using the `--expression` or `-e` flag, they support the following features:
 - binary and unary operators like `&`/`and` or `!`/`not`
 - built-in primitive test sets such as `ephemeral()`, `compile-only()` or `skip()`
 - identity test sets for easier scripting like `all()` and `none()`
@@ -63,10 +63,10 @@ regressions/issue-42
 regressions/issue-33
 ```
 
-The you can simply run `tt run` with the same expression and it will run only those tests.
+Then you can simply run `tt run` with the same expression and it will run only those tests.
 
-If you want to incldue or exclude various directories or tests by identifier you can use patterns.
-Let's you want to only run feature tests, you can a pattern like `c:features` or more correctly `r:^features`.
+If you want to include or exclude various directories or tests by identifier you can use patterns.
+Let's say you want to only run feature tests, you can a pattern like `c:features` or more correctly `r:^features`.
 
 If you run
 ```shell

--- a/docs/book/src/guides/tests.md
+++ b/docs/book/src/guides/tests.md
@@ -1,7 +1,7 @@
 # Writing tests
 To start writing tests, you only need to write regular `typst` scripts, no special syntax or annotations are required.
 
-Let's start with the most common type of tests, regression tests. 
+Let's start with the most common type of tests, regression tests.
 We'll assume you have a normal package directory structure:
 ```txt
 <project>
@@ -11,7 +11,7 @@ We'll assume you have a normal package directory structure:
 ```
 
 ## Regression tests
-Regression tests are found in the `test` directory of your project (remember that this is where your `typst.toml` manifest is found).
+Regression tests are found in the `tests` directory of your project (remember that this is where your `typst.toml` manifest is found).
 
 Let's write our first test, you can run `tt add my-test` to add a new regression test, this creates a new directory called `my-test` inside `tests` and adds a test script and reference document.
 This test is located in `tests/my-test/tests.typ` and is the entrypoint script (like a `main.typ` file).
@@ -164,7 +164,9 @@ See [#73].
 
 </div>
 
+<!--
 The more your project grows
+-->
 
 ## Template tests
 

--- a/docs/book/src/guides/watching.md
+++ b/docs/book/src/guides/watching.md
@@ -3,7 +3,7 @@
 However, you can work around this by using [`watchexec`] or an equivalent tool which re-runs `tytanic` whenever a file in your project changes.
 
 Let's look at a concrete example with `watchexec`.
-Navigate to your project root directory, i.e. that whhich contains your `typst.toml` manifest and run:
+Navigate to your project root directory, i.e. that which contains your `typst.toml` manifest and run:
 ```shell
 watchexec \
   --watch . \
@@ -17,7 +17,7 @@ watchexec \
 Of course a shell alias or task runner definition makes this more convenient.
 While this is running, any change to a file in your project which is not excluded by the patterns proivided using the `--ignore` flag will trigger a re-run of `tt run`.
 
-If you have other files youmay edit which don't influence the outcome of your test suite, then you should ignore them too.
+If you have other files you may edit which don't influence the outcome of your test suite, then you should ignore them too.
 
 <div class="warning">
 

--- a/docs/book/src/quickstart/install.md
+++ b/docs/book/src/quickstart/install.md
@@ -34,7 +34,7 @@ To install `tytanic` from source, you must have a Rust toolchain (Rust **v1.80.0
 
 #### Stable
 ```shell
-cargo install --locked tytanic@v0.1.1
+cargo install --locked tytanic@0.1.1
 ```
 
 #### Nightly

--- a/docs/book/src/reference/test-sets/built-in.md
+++ b/docs/book/src/reference/test-sets/built-in.md
@@ -7,7 +7,7 @@ There are a few available types:
 |`test set`|Represents a set of tests.|
 |`number`|Positive whole numbers.|
 |`string`|Used for patterns containing special characters.|
-|`pattern`|Special syntax for test sets which operator on test identifiers.|
+|`pattern`|Special syntax for test sets which operate on test identifiers.|
 
 A test set expression must always evaluate to a test set, otherwise it is ill-formed, all operators operate on test sets only.
 The following may be valid `set(1) & set("aaa", 2)`, but `set() & 1` is not.
@@ -38,6 +38,6 @@ The following pattern types exist:
 |`e`/`exact`|`exact:mod/name`|Matches by comparing the identifier exactly to the given term.|
 |`c`/`contains`|`c:plot`|Matches by checking if the given term is contained in the identifier.|
 |`r`/`regex`|`regex:mod-[234]/.*`|Matches using the given regex.|
-|`g`/`glob`|`g:foo/**/bar`|Matches using the given glob battern.|
-|`p`/`path`|`p:foo`|Matches using the given glob battern.|
+|`g`/`glob`|`g:foo/**/bar`|Matches using the given glob pattern.|
+|`p`/`path`|`p:foo`|Matches using the given glob pattern.|
 

--- a/docs/book/src/reference/tests/regression-tests.md
+++ b/docs/book/src/reference/tests/regression-tests.md
@@ -1,5 +1,5 @@
 # Regression tests
-Regression tests are those tests found in their on directory identified by a `test.typ` script and are located in `tests`.
+Regression tests are those tests found in their own directory identified by a `test.typ` script and are located in `tests`.
 
 Regression tests are the only tests which have access to an extended Typst standard library.
 This [test library](./lib.md) contains modules and functions to thoroughly test both the success and failure paths of your project.
@@ -8,7 +8,7 @@ This [test library](./lib.md) contains modules and functions to thoroughly test 
 There are three kinds of regression tests:
 - `compile-only`: Tests which are compiled, but not compared to any reference, these don't produce any output.
 - `persistent`: Tests which are compared to persistent reference documents.
-  The references for these tests are stored in a `ref` directory along side the test script as individual pages using PNGs.
+  The references for these tests are stored in a `ref` directory alongside the test script as individual pages using PNGs.
   These tests can be updated with the `tt update` command.
 - `ephemeral`: Tests which are compared to the output of another script.
   The references for these tests are compiled on the fly using a `ref.typ` script.
@@ -24,7 +24,7 @@ The directory path within the test root `tests` in your project is the identifie
 Given a directory within `tests`, it is considered a valid test, if it contains at least a `test.typ` file.
 The strucutre of this directory looks as follows:
 - `test.typ`: The main test script, this is always compiled as the entrypoint.
-- `ref.typ` (optional): This makes a test ephemeral and is used to compile the reference document for eahc invocation.
+- `ref.typ` (optional): This makes a test ephemeral and is used to compile the reference document for each invocation.
 - `ref` (optional, temporary): This makes a test either persistent or ephemeral and is used to store the reference documents.
   If the test is ephemeral this directory is temporary.
 - `out` (temporary): Contains the test output document.
@@ -37,13 +37,13 @@ The kind of a test is determined as follows:
 
 Temporary directories are ignored within the VCS if one is detected, this is currently done by simply adding an ignore file within the directory which ignores all entries inside it.
 
-A test cannot contain other her tests, if a test script is found `tytanic` will not search for any sub tests.
+A test cannot contain other tests, if a test script is found `tytanic` will not search for any sub tests.
 
 Regression test are compiled with the project root as their typst root, such that they can easily access package internals with absolute paths.
 
 ## Comparison
 Ephemeral and persistent tests are curently compared using a simple deviation threshold which determines if two images should be considered the same or different.
-If the images have differnet dimensions consider them different.
+If the images have different dimensions consider them different.
 Given two images of equal dimensions, pair up each pixel and compare them, if any of the 3 channels (red, green, blue) differ by at least `min-delta` count it as a deviation.
 If there are more than `max-deviations` of such deviating pixels, consider the images different.
 


### PR DESCRIPTION
fix some typos that I noticed while reading the docs. Most are inconsequential, but in two instances it actually changed meaning: "tests are found in the `test` directory" (is actually `tests`) and "`cargo install --locked tytanic@v0.1.1`" (version number should not have the "v" prefix -- goes for binstall too, once that's added again)

The only "opinionated" change was commenting out "The more your project grows" with an HTML comment, since that seems to be left in there by accident.