### PR TITLE
filter: Make various `eval::*` types thread-safe

### DIFF
--- a/crates/tytanic-filter/src/eval/mod.rs
+++ b/crates/tytanic-filter/src/eval/mod.rs
@@ -167,3 +167,10 @@ impl Display for Error {
         }
     }
 }
+
+/// Ensure Context<T> is thread safe if T is.
+#[allow(dead_code)]
+fn assert_traits() {
+    tytanic_utils::assert::send::<Context<()>>();
+    tytanic_utils::assert::sync::<Context<()>>();
+}

--- a/crates/tytanic-utils/src/assert.rs
+++ b/crates/tytanic-utils/src/assert.rs
@@ -1,0 +1,5 @@
+/// Statically assert that `T` is [`Send`].
+pub fn send<T: Send>() {}
+
+/// Statically assert that `T` is [`Sync`].
+pub fn sync<T: Sync>() {}

--- a/crates/tytanic-utils/src/lib.rs
+++ b/crates/tytanic-utils/src/lib.rs
@@ -3,6 +3,7 @@
 //! This library makes _*no stability guarantees*_ at the moment and likely
 //! won't ever.
 
+pub mod assert;
 pub mod fmt;
 pub mod fs;
 pub mod path;

--- a/crates/tytanic/src/ui.rs
+++ b/crates/tytanic/src/ui.rs
@@ -646,11 +646,8 @@ impl<W: WriteColor> CWrite for Indented<W> {
 /// Ensure Ui is thread safe.
 #[allow(dead_code)]
 fn assert_traits() {
-    fn assert_send<T: Send>() {}
-    fn assert_sync<T: Sync>() {}
-
-    assert_send::<Ui>();
-    assert_sync::<Ui>();
+    tytanic_utils::assert::send::<Ui>();
+    tytanic_utils::assert::sync::<Ui>();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #128.

<!--
  Please take a look at the contribution guidelines, they are outlined in
  CONTRIBUTING.md.

  Heres the gist of it:
  - Document each commit properly
  - Squash fixup commits
  - Link to issues you fix in botht he commit description and this PR description.
-->
