### PR TITLE
build: Embed typst version at compile time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3257,6 +3257,7 @@ dependencies = [
  "serde_json",
  "termcolor",
  "thiserror 1.0.69",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "tracing-tree",

--- a/crates/tytanic/Cargo.toml
+++ b/crates/tytanic/Cargo.toml
@@ -50,6 +50,9 @@ typst-kit.workspace = true
 typst-syntax.workspace = true
 typst.workspace = true
 
+[build-dependencies]
+toml.workspace = true
+
 [features]
 default = ["embed-fonts"]
 embed-fonts = ["typst-kit/embed-fonts"]

--- a/crates/tytanic/build.rs
+++ b/crates/tytanic/build.rs
@@ -1,0 +1,18 @@
+use toml::{Table, Value};
+
+fn main() {
+    let lock: Table = toml::from_str(include_str!("../../Cargo.lock")).unwrap();
+    let packages = lock["package"].as_array().unwrap();
+    let typst = packages
+        .iter()
+        .filter_map(Value::as_table)
+        .find(|t| {
+            t.get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|n| n == "typst")
+        })
+        .unwrap();
+    let typst_version = typst["version"].as_str().unwrap();
+
+    println!("cargo::rustc-env=TYTANIC_TYPST_VERSION={}", typst_version);
+}

--- a/crates/tytanic/src/cli/commands/util/about.rs
+++ b/crates/tytanic/src/cli/commands/util/about.rs
@@ -7,7 +7,7 @@ use super::Context;
 pub fn run(ctx: &mut Context) -> eyre::Result<()> {
     let mut w = ctx.ui.stderr();
     writeln!(w, "Version: {}", env!("CARGO_PKG_VERSION"))?;
-    writeln!(w, "Typst Version: 0.12.0")?;
+    writeln!(w, "Typst Version: {}", env!("TYTANIC_TYPST_VERSION"))?;
 
     Ok(())
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## Fixes
 - Don't panic when trying to update non-persistent tests
+- Don't report old version of typst in `util about`
 
 ---
 


### PR DESCRIPTION
I'm on the fence about this, build scripts in rust are not well-designed, and it seems there's an increase of compile time of 1 second for incremental compiles when using a build script like this.

The upside is that this means the compiler will ensure a correct version is used in the about command.

Closes #162.