### PR TITLE
cli: Promote nested tests to an error

### DIFF
--- a/crates/tytanic/src/cli/mod.rs
+++ b/crates/tytanic/src/cli/mod.rs
@@ -189,21 +189,21 @@ impl Context<'_> {
         let suite = Suite::collect(project)?;
 
         if !suite.nested().is_empty() {
-            writeln!(self.ui.warn()?, "Found nested tests")?;
+            writeln!(self.ui.error()?, "Found nested tests")?;
 
+            let mut w = self.ui.hint()?;
+            writeln!(w, "This is no longer supported")?;
             writeln!(
-                self.ui.hint()?,
-                "This is no longer supported, these tests will be ignored"
-            )?;
-            writeln!(
-                self.ui.hint()?,
-                "This will become a hard error in a future version"
+                w,
+                "Your nested tests will be silently ignored in future versions!",
             )?;
 
             let mut w = self.ui.hint()?;
             write!(w, "You can run ")?;
             cwrite!(colored(w, Color::Cyan), "tt util migrate")?;
             writeln!(w, " to automatically move the tests")?;
+
+            eyre::bail!(OperationFailure);
         }
 
         Ok(suite)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed panic on non-existent paths in the manifest.
 - Update MSRV to `1.88`
 - Update Typst to `0.14.0-rc.1`
+- Promote detection of nested tests to an error
 
 ## Fixes
 - Don't panic when trying to update non-persistent tests


### PR DESCRIPTION
This was added as a warning in `v0.2.0` and is now an error, the detection will removed in `v0.4.0`.

<!--
  Please take a look at the contribution guidelines, they are outlined in
  CONTRIBUTING.md.

  Here's the gist of it:
  - Document each commit properly
  - Squash fixup commits
  - Link to issues you fix in both the commit description and this PR
    description.
-->
