### PR TITLE
core: Ensure correct transitive file lookup

### DIFF
--- a/assets/test-package/src/internal.typ
+++ b/assets/test-package/src/internal.typ
@@ -1,0 +1,5 @@
+#let helper(body) = {
+  assert.eq(type(body), str, message: "`body` must be of type str")
+
+  [Helper: #body]
+}

--- a/assets/test-package/src/lib.typ
+++ b/assets/test-package/src/lib.typ
@@ -1,13 +1,9 @@
+#import  "/src/internal.typ": helper
+
 #let template(title: none) = body => {
   assert.ne(title, none, message: "`title` is not optional")
 
   align(center + horizon, title)
   pagebreak()
   body
-}
-
-#let helper(body) = {
-  assert.eq(type(body), str, message: "`body` must be of type str")
-
-  [Helper: #body]
 }

--- a/assets/test-package/template/chapter.typ
+++ b/assets/test-package/template/chapter.typ
@@ -1,0 +1,1 @@
+Hello World

--- a/assets/test-package/template/main.typ
+++ b/assets/test-package/template/main.typ
@@ -5,3 +5,5 @@
 )
 
 #helper[Bar]
+
+#import "chapter.typ"

--- a/assets/test-package/typst.toml
+++ b/assets/test-package/typst.toml
@@ -1,5 +1,5 @@
 [package]
-entrypoint = "lib.typ"
+entrypoint = "src/lib.typ"
 name = "template"
 version = "0.1.0"
 authors = ["John Doe <john@doe.com>"]

--- a/crates/tytanic/src/world.rs
+++ b/crates/tytanic/src/world.rs
@@ -31,7 +31,6 @@ use tytanic_core::world_builder::ProvideDatetime;
 use tytanic_core::world_builder::ProvideFile;
 use tytanic_core::world_builder::ProvideFont;
 use tytanic_core::world_builder::ProvideLibrary;
-use tytanic_core::world_builder::TemplateFileProviderShim;
 use tytanic_core::world_builder::datetime::FixedDateProvider;
 use tytanic_core::world_builder::file::FilesystemFileProvider;
 use tytanic_core::world_builder::font::FilesystemFontProvider;
@@ -94,14 +93,11 @@ pub fn template_file_provider(
         version: manifest.package.version,
     };
 
-    Box::new(TemplateFileProviderShim::new(
-        FilesystemFileProvider::new(project.root(), Some(package_storage(package_opts))),
-        FilesystemFileProvider::new(
-            project.template_root().unwrap(),
-            Some(package_storage(package_opts)),
-        ),
-        spec,
-    )) as _
+    Box::new(FilesystemFileProvider::with_overrides(
+        project.template_root().unwrap(),
+        [(spec, project.root().to_path_buf())],
+        Some(package_storage(package_opts)),
+    ))
 }
 
 /// A font provider that provides embedded and system fonts.


### PR DESCRIPTION
Because the `PackageSpec` was previously removed for re-routes to the template package root itself the typst internal world lookup created `FileId`s for this root which had no spec either. This obviously creates paths which the provider can no longer distinguish from normal template paths.

Incidentally, this fix also allows for more overrides to be placed in the provider directly which could be used for patching dependencies in tests. However, this also comes with the downside of not allowing the re-routing with a virtual prvoider, but this was not previously used.

Fixes #229

<!--
  Please take a look at the contribution guidelines, they are outlined in
  CONTRIBUTING.md.

  Here's the gist of it:
  - Document each commit properly
  - Squash fixup commits
  - Link to issues you fix in both the commit description and this PR
    description.
-->
