### PR TITLE
github: Disable dependabot for cargo deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,26 @@
 version: 2
 
 updates:
-- package-ecosystem: "cargo"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  commit-message:
-    prefix: "cargo:"
-  groups:
-    cargo-dependencies:
-      patterns:
-      - "*"
-  labels: []
+  # - package-ecosystem: "cargo"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   commit-message:
+  #     prefix: "cargo:"
+  #   groups:
+  #     cargo-dependencies:
+  #       patterns:
+  #       - "*"
+  #   labels: []
 
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
-  commit-message:
-    prefix: "github:"
-  groups:
-    github-dependencies:
-      patterns:
-      - "*"
-  labels: []
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "github:"
+    groups:
+      github-dependencies:
+        patterns:
+          - "*"
+    labels: []


### PR DESCRIPTION
See commit messages.

## Related Issues
<!--
  Link related issues here, even if you have done so in your commit descriptions too, this is
  primarily so GitHub auto closes the issues.

  You can do so by adding text such as "Closes #123" or "Fixes #456".

  Remove this section if there are no related issues to close.
-->

## Checklist
<!-- Check items that apply, leave those that don't. -->

- [ ] I have structured my commits according to the [commit guidelines] (if applicable).
- [ ] I have added tests for new features (if applicable).
- [ ] I have updated the documentation (if applicable).

[commit guidelines]: https://github.com/typst-community/tytanic/blob/main/docs/commit-guidelines.md
