### PR TITLE
fix: derive Typst version from workspace Cargo.toml

### DIFF
--- a/crates/tytanic/build.rs
+++ b/crates/tytanic/build.rs
@@ -1,0 +1,15 @@
+use std::path::Path;
+
+fn main() {
+    let manifest = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../Cargo.toml");
+    let content = std::fs::read_to_string(&manifest).expect("workspace Cargo.toml");
+    let table: toml::Table = content.parse().expect("valid TOML");
+
+    let version = table["workspace"]["dependencies"]["typst"]
+        .as_str()
+        .expect("typst version string");
+
+    println!("cargo::rerun-if-changed=../../Cargo.toml");
+    println!("cargo::rustc-env=TYPST_VERSION={version}");
+}

--- a/crates/tytanic/src/cli/commands/util/about.rs
+++ b/crates/tytanic/src/cli/commands/util/about.rs
@@ -7,7 +7,7 @@ use super::Context;
 pub fn run(ctx: &mut Context) -> eyre::Result<()> {
     let mut w = ctx.ui.stderr();
     writeln!(w, "Version: {}", env!("CARGO_PKG_VERSION"))?;
-    writeln!(w, "Typst Version: 0.14.0-rc.1")?;
+    writeln!(w, "Typst Version: {}", env!("TYPST_VERSION"))?;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- Adds a build script that reads the `typst` dependency version from the workspace `Cargo.toml`
- Sets `TYPST_VERSION` as a compile-time env var via `cargo::rustc-env`
- Replaces the hardcoded "0.14.0-rc.1" string in `about.rs` with `env!("TYPST_VERSION")`
- The `toml` build-dependency was already declared but unused; this puts it to work

Before: `Typst Version: 0.14.0-rc.1`
After: `Typst Version: 0.14.2`

Future Typst version bumps in `Cargo.toml` will automatically update the about output.

Closes #262

## Test plan

- [x] `cargo run -p tytanic -- util about` shows `Typst Version: 0.14.2`
- [x] `cargo test -p tytanic` passes
- [x] `cargo build -p tytanic` succeeds