### PR TITLE
core: Path{,Buf} -> camino::Utf8Path{,Buf}

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "camino"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3493,6 +3502,7 @@ name = "tytanic"
 version = "0.3.4"
 dependencies = [
  "assert_cmd",
+ "camino",
  "chrono",
  "clap",
  "clap_complete",
@@ -3530,6 +3540,7 @@ name = "tytanic-core"
 version = "0.3.4"
 dependencies = [
  "bytemuck",
+ "camino",
  "chrono",
  "comemo",
  "dirs",
@@ -3570,6 +3581,7 @@ dependencies = [
 name = "tytanic-utils"
 version = "0.3.4"
 dependencies = [
+ "camino",
  "ecow",
  "temp-dir",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tytanic-utils = { version = "0.3.3", path = "crates/tytanic-utils" }
 
 assert_cmd = "2.1.2"
 assert_fs = "1.1.2"
+camino = "1.2.2"
 chrono = "0.4.43"
 clap = "4.5.54"
 clap_complete = "4.5.65"

--- a/crates/tytanic-core/Cargo.toml
+++ b/crates/tytanic-core/Cargo.toml
@@ -16,6 +16,7 @@ readme.workspace = true
 tytanic-filter.workspace = true
 tytanic-utils.workspace = true
 
+camino.workspace = true
 chrono.workspace = true
 comemo.workspace = true
 dirs.workspace = true

--- a/crates/tytanic-core/src/project/mod.rs
+++ b/crates/tytanic-core/src/project/mod.rs
@@ -1,13 +1,13 @@
-//! Discovering, loading and managing typst projects.
+//! Discovering, loading, and managing Typst projects.
 
 use std::collections::BTreeMap;
 use std::fs;
 use std::io;
 use std::ops::Deref;
-use std::path::Component;
-use std::path::Path;
-use std::path::PathBuf;
 
+use camino::Utf8Component;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use ecow::EcoString;
 use serde::Deserialize;
 use thiserror::Error;
@@ -33,7 +33,7 @@ pub const MANIFEST_FILE: &str = "typst.toml";
 /// to load a project.
 #[derive(Debug, Clone)]
 pub struct ShallowProject {
-    root: PathBuf,
+    root: Utf8PathBuf,
     vcs: Option<Vcs>,
 }
 
@@ -43,7 +43,7 @@ impl ShallowProject {
     /// It is recommended to canonicalize them, but it is not strictly necessary.
     pub fn new<P, V>(project: P, vcs: V) -> Self
     where
-        P: Into<PathBuf>,
+        P: Into<Utf8PathBuf>,
         V: Into<Option<Vcs>>,
     {
         Self {
@@ -59,7 +59,7 @@ impl ShallowProject {
     /// manifest is found. If it is `true`, then `dir` is used as the project
     /// root.
     #[tracing::instrument(skip(dir) fields(dir = ?dir.as_ref()), ret)]
-    pub fn discover<P: AsRef<Path>>(
+    pub fn discover<P: AsRef<Utf8Path>>(
         dir: P,
         search_manifest: bool,
     ) -> Result<Option<Self>, io::Error> {
@@ -165,7 +165,7 @@ impl ShallowProject {
         &self,
         config: &ProjectConfig,
     ) -> Result<Option<String>, io::Error> {
-        let root = Path::new(&config.unit_tests_root);
+        let root = Utf8Path::new(&config.unit_tests_root);
         let template = root.join("template.typ");
 
         fs::read_to_string(template).ignore(io_not_found)
@@ -177,12 +177,12 @@ impl ShallowProject {
     ///
     /// The project root is used to resolve absolute paths in typst when
     /// executing tests.
-    pub fn root(&self) -> &Path {
+    pub fn root(&self) -> &Utf8Path {
         &self.root
     }
 
     /// Returns the path to the project manifest (`typst.toml`).
-    pub fn manifest_file(&self) -> PathBuf {
+    pub fn manifest_file(&self) -> Utf8PathBuf {
         self.root.join(MANIFEST_FILE)
     }
 
@@ -190,7 +190,7 @@ impl ShallowProject {
     ///
     /// The VCS root is used for properly handling non-persistent storage of
     /// tests.
-    pub fn vcs_root(&self) -> Option<&Path> {
+    pub fn vcs_root(&self) -> Option<&Utf8Path> {
         self.vcs.as_ref().and_then(Vcs::root)
     }
 }
@@ -208,7 +208,7 @@ pub struct Project {
 
 impl Project {
     /// Create a new empty project.
-    pub fn new<P: Into<PathBuf>>(root: P) -> Self {
+    pub fn new<P: Into<Utf8PathBuf>>(root: P) -> Self {
         Self {
             base: ShallowProject {
                 root: root.into(),
@@ -246,7 +246,7 @@ impl Project {
 
     /// Checks the given directory for a project root, returning `true` if it
     /// was found.
-    pub fn exists_at(dir: &Path) -> io::Result<bool> {
+    pub fn exists_at(dir: &Utf8Path) -> io::Result<bool> {
         if dir.join(MANIFEST_FILE).try_exists()? {
             return Ok(true);
         }
@@ -288,7 +288,7 @@ impl Project {
     }
 
     /// Returns the [`Vcs`] this project is managed by or `None` if no supported
-    /// Vcs was found.
+    /// VCS was found.
     pub fn vcs(&self) -> Option<&Vcs> {
         self.base.vcs.as_ref()
     }
@@ -299,12 +299,12 @@ impl Project {
     /// root where the test suite is located.
     ///
     /// The test root is used to resolve test identifiers.
-    pub fn unit_tests_root(&self) -> PathBuf {
+    pub fn unit_tests_root(&self) -> Utf8PathBuf {
         self.root().join(&self.config.unit_tests_root)
     }
 
     /// Returns the root path of the template directory.
-    pub fn template_root(&self) -> Option<PathBuf> {
+    pub fn template_root(&self) -> Option<Utf8PathBuf> {
         self.manifest
             .as_ref()
             .and_then(|m| m.template.as_ref())
@@ -312,7 +312,7 @@ impl Project {
     }
 
     /// Returns the entrypoint script inside the template directory.
-    pub fn template_entrypoint(&self) -> Option<PathBuf> {
+    pub fn template_entrypoint(&self) -> Option<Utf8PathBuf> {
         self.manifest
             .as_ref()
             .and_then(|m| m.template.as_ref())
@@ -326,49 +326,49 @@ impl Project {
 
     /// Returns the path to the unit test template, that is, the source template to
     /// use when generating new unit tests.
-    pub fn unit_test_template_file(&self) -> PathBuf {
+    pub fn unit_test_template_file(&self) -> Utf8PathBuf {
         let mut dir = self.unit_tests_root();
         dir.push("template.typ");
         dir
     }
 
     /// Create a path to the test directory for the given identifier.
-    pub fn unit_test_dir(&self, id: &Id) -> PathBuf {
+    pub fn unit_test_dir(&self, id: &Id) -> Utf8PathBuf {
         let mut dir = self.unit_tests_root();
         dir.extend(id.components());
         dir
     }
 
     /// Create a path to the test script for the given identifier.
-    pub fn unit_test_script(&self, id: &Id) -> PathBuf {
+    pub fn unit_test_script(&self, id: &Id) -> Utf8PathBuf {
         let mut dir = self.unit_test_dir(id);
         dir.push("test.typ");
         dir
     }
 
     /// Create a path to the reference script for the given identifier.
-    pub fn unit_test_ref_script(&self, id: &Id) -> PathBuf {
+    pub fn unit_test_ref_script(&self, id: &Id) -> Utf8PathBuf {
         let mut dir = self.unit_test_dir(id);
         dir.push("ref.typ");
         dir
     }
 
     /// Create a path to the reference directory for the given identifier.
-    pub fn unit_test_ref_dir(&self, id: &Id) -> PathBuf {
+    pub fn unit_test_ref_dir(&self, id: &Id) -> Utf8PathBuf {
         let mut dir = self.unit_test_dir(id);
         dir.push("ref");
         dir
     }
 
     /// Create a path to the output directory for the given identifier.
-    pub fn unit_test_out_dir(&self, id: &Id) -> PathBuf {
+    pub fn unit_test_out_dir(&self, id: &Id) -> Utf8PathBuf {
         let mut dir = self.unit_test_dir(id);
         dir.push("out");
         dir
     }
 
     /// Create a path to the difference directory for the given identifier.
-    pub fn unit_test_diff_dir(&self, id: &Id) -> PathBuf {
+    pub fn unit_test_diff_dir(&self, id: &Id) -> Utf8PathBuf {
         let mut dir = self.unit_test_dir(id);
         dir.push("diff");
         dir
@@ -383,7 +383,7 @@ impl Deref for Project {
     }
 }
 
-fn validate_manifest(root: &Path, manifest: &PackageManifest) -> Result<(), ValidationError> {
+fn validate_manifest(root: &Utf8Path, manifest: &PackageManifest) -> Result<(), ValidationError> {
     let PackageManifest {
         package: _,
         template,
@@ -449,7 +449,7 @@ fn validate_manifest(root: &Path, manifest: &PackageManifest) -> Result<(), Vali
     Ok(())
 }
 
-fn validate_config(root: &Path, config: &ProjectConfig) -> Result<(), ValidationError> {
+fn validate_config(root: &Utf8Path, config: &ProjectConfig) -> Result<(), ValidationError> {
     let ProjectConfig {
         unit_tests_root,
         defaults: _,
@@ -487,9 +487,12 @@ fn validate_config(root: &Path, config: &ProjectConfig) -> Result<(), Validation
     Ok(())
 }
 
-fn is_trivial_path<P: AsRef<Path>>(path: P) -> bool {
+fn is_trivial_path<P: AsRef<Utf8Path>>(path: P) -> bool {
     let path = path.as_ref();
-    path.is_relative() && path.components().all(|c| matches!(c, Component::Normal(_)))
+    path.is_relative()
+        && path
+            .components()
+            .all(|c| matches!(c, Utf8Component::Normal(_)))
 }
 
 /// Returned by [`ShallowProject::load`].
@@ -534,7 +537,7 @@ pub enum ValidationErrorCause {
         field: EcoString,
 
         /// The field as it was resolved.
-        resolved: PathBuf,
+        resolved: Utf8PathBuf,
     },
 }
 
@@ -565,7 +568,7 @@ pub enum ManifestError {
     #[error("an error occurred while parsing the project manifest")]
     Parse(#[from] toml::de::Error),
 
-    /// An io error occurred.
+    /// An IO error occurred.
     #[error("an io error occurred")]
     Io(#[from] io::Error),
 }
@@ -593,11 +596,11 @@ mod tests {
 
         assert_eq!(
             project.template_root(),
-            Some(PathBuf::from_iter(["root", "foo"]))
+            Some(Utf8PathBuf::from_iter(["root", "foo"]))
         );
         assert_eq!(
             project.template_entrypoint(),
-            Some(PathBuf::from_iter(["root", "foo", "bar.typ"]))
+            Some(Utf8PathBuf::from_iter(["root", "foo", "bar.typ"]))
         );
     }
 
@@ -608,15 +611,15 @@ mod tests {
 
         assert_eq!(
             project.unit_tests_root(),
-            PathBuf::from_iter(["root", "tests"])
+            Utf8PathBuf::from_iter(["root", "tests"])
         );
         assert_eq!(
             project.unit_test_dir(&id),
-            PathBuf::from_iter(["root", "tests", "a", "b"])
+            Utf8PathBuf::from_iter(["root", "tests", "a", "b"])
         );
         assert_eq!(
             project.unit_test_script(&id),
-            PathBuf::from_iter(["root", "tests", "a", "b", "test.typ"])
+            Utf8PathBuf::from_iter(["root", "tests", "a", "b", "test.typ"])
         );
 
         let project = Project::new("root").with_config(ProjectConfig {
@@ -626,19 +629,19 @@ mod tests {
 
         assert_eq!(
             project.unit_test_ref_script(&id),
-            PathBuf::from_iter(["root", "foo", "a", "b", "ref.typ"])
+            Utf8PathBuf::from_iter(["root", "foo", "a", "b", "ref.typ"])
         );
         assert_eq!(
             project.unit_test_ref_dir(&id),
-            PathBuf::from_iter(["root", "foo", "a", "b", "ref"])
+            Utf8PathBuf::from_iter(["root", "foo", "a", "b", "ref"])
         );
         assert_eq!(
             project.unit_test_out_dir(&id),
-            PathBuf::from_iter(["root", "foo", "a", "b", "out"])
+            Utf8PathBuf::from_iter(["root", "foo", "a", "b", "out"])
         );
         assert_eq!(
             project.unit_test_diff_dir(&id),
-            PathBuf::from_iter(["root", "foo", "a", "b", "diff"])
+            Utf8PathBuf::from_iter(["root", "foo", "a", "b", "diff"])
         );
     }
 

--- a/crates/tytanic-core/src/project/vcs.rs
+++ b/crates/tytanic-core/src/project/vcs.rs
@@ -10,8 +10,9 @@ use std::fmt::Debug;
 use std::fmt::Display;
 use std::fs;
 use std::io;
-use std::path::Path;
-use std::path::PathBuf;
+
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 
 use super::Project;
 use crate::test::UnitTest;
@@ -45,7 +46,7 @@ pub enum Kind {
 /// and `diff` directories.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Vcs {
-    root: Option<PathBuf>,
+    root: Option<Utf8PathBuf>,
     kind: Kind,
 }
 
@@ -53,7 +54,7 @@ impl Vcs {
     /// Creates a new VCS with the given root directory and kind.
     pub fn new<I>(root: I, kind: Kind) -> Self
     where
-        I: Into<PathBuf>,
+        I: Into<Utf8PathBuf>,
     {
         Self {
             root: Some(root.into()),
@@ -69,7 +70,7 @@ impl Vcs {
     /// Checks the given directory for a VCS root, returning which kind was
     /// found.
     #[tracing::instrument(ret)]
-    pub fn exists_at(dir: &Path) -> io::Result<Option<Kind>> {
+    pub fn exists_at(dir: &Utf8Path) -> io::Result<Option<Kind>> {
         if dir.join(".git").try_exists()?
             || dir.join(".jj").try_exists()?
             || dir.join(".sl").try_exists()?
@@ -87,7 +88,7 @@ impl Vcs {
 
 impl Vcs {
     /// The root of this Vcs' repository.
-    pub fn root(&self) -> Option<&Path> {
+    pub fn root(&self) -> Option<&Utf8Path> {
         self.root.as_deref()
     }
 

--- a/crates/tytanic-core/src/suite.rs
+++ b/crates/tytanic-core/src/suite.rs
@@ -1,16 +1,15 @@
 //! Loading and filtering of test suites, suites contain test and supplementary
 //! fields for test templates, custom test set bindings and other information
-//! necessary for managing, filtering and running tests.
+//! necessary for managing, filtering, and running tests.
 
 use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::btree_map;
-use std::fs;
 use std::io;
-use std::path::Path;
 use std::time::Duration;
 use std::time::Instant;
 
+use camino::Utf8Path;
 use thiserror::Error;
 use tytanic_filter::ExpressionFilter;
 use tytanic_filter::eval;
@@ -55,7 +54,7 @@ impl Suite {
         }
 
         let root = project.unit_tests_root();
-        let Some(read_dir) = root.read_dir().ignore(io_not_found)? else {
+        let Some(read_dir) = root.read_dir_utf8().ignore(io_not_found)? else {
             tracing::debug!(?root, "test root not found, ignoring");
             return Ok(this);
         };
@@ -101,14 +100,10 @@ impl Suite {
     }
 
     /// Recursively collect tests in the given directory.
-    fn collect_dir(&mut self, project: &Project, dir: &Path) -> Result<(), Error> {
+    fn collect_dir(&mut self, project: &Project, dir: &Utf8Path) -> Result<(), Error> {
         let abs = project.unit_tests_root().join(dir);
 
-        if dir
-            .file_name()
-            .and_then(|p| p.to_str())
-            .is_some_and(|p| p.starts_with('.'))
-        {
+        if dir.file_name().is_some_and(|p| p.starts_with('.')) {
             tracing::debug!(?dir, "skipping hidden directory");
             return Ok(());
         }
@@ -128,7 +123,7 @@ impl Suite {
         }
 
         tracing::trace!(?dir, "collecting sub directories");
-        for entry in fs::read_dir(&abs)? {
+        for entry in abs.read_dir_utf8()? {
             let entry = entry?;
 
             if entry.metadata()?.is_dir() {

--- a/crates/tytanic-core/src/test/unit.rs
+++ b/crates/tytanic-core/src/test/unit.rs
@@ -648,7 +648,7 @@ mod tests {
 
                 let source = test.load_source(&project).unwrap();
                 assert_eq!(
-                    source.id().vpath().resolve(root).unwrap(),
+                    source.id().vpath().resolve(root.as_std_path()).unwrap(),
                     root.join("tests/fancy/test.typ")
                 );
             },

--- a/crates/tytanic-core/src/world_builder/file.rs
+++ b/crates/tytanic-core/src/world_builder/file.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 use std::sync::MutexGuard;
 
+use camino::Utf8PathBuf;
 use ecow::eco_format;
 use typst::diag::FileError;
 use typst::diag::FileResult;
@@ -136,7 +137,7 @@ impl VirtualFileSlot {
 #[derive(Debug)]
 pub struct FilesystemFileProvider {
     root: PathBuf,
-    overrides: HashMap<PackageSpec, PathBuf>,
+    overrides: HashMap<PackageSpec, Utf8PathBuf>,
     slots: Mutex<HashMap<FileId, FileSlot>>,
     package_storage: Option<PackageStorage>,
 }
@@ -170,7 +171,7 @@ impl FilesystemFileProvider {
     ) -> Self
     where
         P: Into<PathBuf>,
-        I: IntoIterator<Item = (PackageSpec, PathBuf)>,
+        I: IntoIterator<Item = (PackageSpec, Utf8PathBuf)>,
     {
         Self {
             root: root.into(),
@@ -188,7 +189,7 @@ impl FilesystemFileProvider {
     }
 
     /// The package spec overrides of this file provider.
-    pub fn overrides(&self) -> &HashMap<PackageSpec, PathBuf> {
+    pub fn overrides(&self) -> &HashMap<PackageSpec, Utf8PathBuf> {
         &self.overrides
     }
 
@@ -288,7 +289,7 @@ impl FileSlot {
     pub fn source(
         &mut self,
         root: &Path,
-        overrides: &HashMap<PackageSpec, PathBuf>,
+        overrides: &HashMap<PackageSpec, Utf8PathBuf>,
         package_storage: Option<&PackageStorage>,
         progress: &mut dyn Progress,
     ) -> FileResult<Source> {
@@ -310,7 +311,7 @@ impl FileSlot {
     pub fn bytes(
         &mut self,
         root: &Path,
-        overrides: &HashMap<PackageSpec, PathBuf>,
+        overrides: &HashMap<PackageSpec, Utf8PathBuf>,
         package_storage: Option<&PackageStorage>,
         progress: &mut dyn Progress,
     ) -> FileResult<Bytes> {
@@ -385,7 +386,7 @@ impl<T: Clone> SlotCell<T> {
 fn system_path(
     root: &Path,
     id: FileId,
-    overrides: &HashMap<PackageSpec, PathBuf>,
+    overrides: &HashMap<PackageSpec, Utf8PathBuf>,
     package_storage: Option<&PackageStorage>,
     progress: &mut dyn Progress,
 ) -> FileResult<PathBuf> {
@@ -397,7 +398,7 @@ fn system_path(
     if let Some(spec) = id.package() {
         if let Some(local_root) = overrides.get(spec) {
             tracing::trace!(?spec, ?local_root, "resolving self reference locally");
-            root = local_root;
+            root = local_root.as_std_path();
         } else if let Some(storage) = package_storage {
             tracing::trace!(?spec, "preparing package");
             buf = storage.prepare_package(spec, progress)?;
@@ -425,7 +426,7 @@ fn system_path(
 fn read(
     id: FileId,
     root: &Path,
-    overrides: &HashMap<PackageSpec, PathBuf>,
+    overrides: &HashMap<PackageSpec, Utf8PathBuf>,
     package_storage: Option<&PackageStorage>,
     progress: &mut dyn Progress,
 ) -> FileResult<Vec<u8>> {

--- a/crates/tytanic-utils/Cargo.toml
+++ b/crates/tytanic-utils/Cargo.toml
@@ -13,6 +13,7 @@ keywords.workspace = true
 readme.workspace = true
 
 [dependencies]
+camino.workspace = true
 ecow.workspace = true
 temp-dir.workspace = true
 toml.workspace = true

--- a/crates/tytanic-utils/src/fs.rs
+++ b/crates/tytanic-utils/src/fs.rs
@@ -6,9 +6,9 @@ use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::fs;
 use std::io;
-use std::path::Path;
-use std::path::PathBuf;
 
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use temp_dir::TempDir;
 
 use crate::result::ResultEx;
@@ -29,9 +29,9 @@ pub const TEMP_DIR_PREFIX: &str = "tytanic-utils";
 /// ```
 pub fn create_dir<P>(path: P, all: bool) -> io::Result<()>
 where
-    P: AsRef<Path>,
+    P: AsRef<Utf8Path>,
 {
-    fn inner(path: &Path, all: bool) -> io::Result<()> {
+    fn inner(path: &Utf8Path, all: bool) -> io::Result<()> {
         let res = if all {
             fs::create_dir_all(path)
         } else {
@@ -54,9 +54,9 @@ where
 /// ```
 pub fn remove_file<P>(path: P) -> io::Result<()>
 where
-    P: AsRef<Path>,
+    P: AsRef<Utf8Path>,
 {
-    fn inner(path: &Path) -> io::Result<()> {
+    fn inner(path: &Utf8Path) -> io::Result<()> {
         std::fs::remove_file(path).ignore_default(io_not_found)
     }
 
@@ -74,9 +74,9 @@ where
 /// ```
 pub fn remove_dir<P>(path: P, all: bool) -> io::Result<()>
 where
-    P: AsRef<Path>,
+    P: AsRef<Utf8Path>,
 {
-    fn inner(path: &Path, all: bool) -> io::Result<()> {
+    fn inner(path: &Utf8Path, all: bool) -> io::Result<()> {
         let res = if all {
             fs::remove_dir_all(path)
         } else {
@@ -115,9 +115,9 @@ where
 /// ```
 pub fn ensure_empty_dir<P>(path: P, all: bool) -> io::Result<()>
 where
-    P: AsRef<Path>,
+    P: AsRef<Utf8Path>,
 {
-    fn inner(path: &Path, all: bool) -> io::Result<()> {
+    fn inner(path: &Utf8Path, all: bool) -> io::Result<()> {
         let res = remove_dir(path, true);
         if all {
             // If there was nothing to clear, then we simply go on to creation.
@@ -137,8 +137,15 @@ where
 #[derive(Debug)]
 pub struct TempTestEnv {
     root: TempDir,
-    found: BTreeMap<PathBuf, Option<Vec<u8>>>,
-    expected: BTreeMap<PathBuf, Option<Option<Vec<u8>>>>,
+    found: BTreeMap<Utf8PathBuf, Option<Vec<u8>>>,
+    expected: BTreeMap<Utf8PathBuf, Option<Option<Vec<u8>>>>,
+}
+
+impl TempTestEnv {
+    fn root(&self) -> &Utf8Path {
+        Utf8Path::from_path(self.root.path())
+            .expect("prefix and temp dir should be UTF-8 on sane platforms")
+    }
 }
 
 /// Set up the project structure.
@@ -149,20 +156,24 @@ pub struct Setup(TempTestEnv);
 impl Setup {
     /// Create a directory and all its parents within the test root.
     ///
-    /// May panic if io errors are encountered.
-    pub fn setup_dir<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
-        let abs_path = self.0.root.path().join(path.as_ref());
+    /// May panic if IO errors are encountered.
+    pub fn setup_dir<P: AsRef<Utf8Path>>(&mut self, path: P) -> &mut Self {
+        let abs_path = self.0.root().join(path.as_ref());
         create_dir(abs_path, true).unwrap();
         self
     }
 
     /// Create a file and all its parent directories within the test root.
     ///
-    /// May panic if io errors are encountered.
-    pub fn setup_file<P: AsRef<Path>>(&mut self, path: P, content: impl AsRef<[u8]>) -> &mut Self {
-        let abs_path = self.0.root.path().join(path.as_ref());
+    /// May panic if IO errors are encountered.
+    pub fn setup_file<P: AsRef<Utf8Path>>(
+        &mut self,
+        path: P,
+        content: impl AsRef<[u8]>,
+    ) -> &mut Self {
+        let abs_path = self.0.root().join(path.as_ref());
         let parent = abs_path.parent().unwrap();
-        if parent != self.0.root.path() {
+        if parent != self.0.root() {
             create_dir(parent, true).unwrap();
         }
 
@@ -173,11 +184,11 @@ impl Setup {
 
     /// Create a directory and all its parents within the test root.
     ///
-    /// May panic if io errors are encountered.
-    pub fn setup_file_empty<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
-        let abs_path = self.0.root.path().join(path.as_ref());
+    /// May panic if IO errors are encountered.
+    pub fn setup_file_empty<P: AsRef<Utf8Path>>(&mut self, path: P) -> &mut Self {
+        let abs_path = self.0.root().join(path.as_ref());
         let parent = abs_path.parent().unwrap();
-        if parent != self.0.root.path() {
+        if parent != self.0.root() {
             create_dir(parent, true).unwrap();
         }
 
@@ -193,19 +204,19 @@ pub struct Expect(TempTestEnv);
 
 impl Expect {
     /// Ensure a directory exists after a test ran.
-    pub fn expect_dir<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+    pub fn expect_dir<P: AsRef<Utf8Path>>(&mut self, path: P) -> &mut Self {
         self.0.add_expected(path.as_ref().to_path_buf(), None);
         self
     }
 
     /// Ensure a file exists after a test ran.
-    pub fn expect_file<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+    pub fn expect_file<P: AsRef<Utf8Path>>(&mut self, path: P) -> &mut Self {
         self.0.add_expected(path.as_ref().to_path_buf(), Some(None));
         self
     }
 
     /// Ensure a file with the given content exists after a test ran.
-    pub fn expect_file_content<P: AsRef<Path>>(
+    pub fn expect_file_content<P: AsRef<Utf8Path>>(
         &mut self,
         path: P,
         content: impl AsRef<[u8]>,
@@ -217,7 +228,7 @@ impl Expect {
     }
 
     /// Ensure an empty file exists after a test ran.
-    pub fn expect_file_empty<P: AsRef<Path>>(&mut self, path: P) -> &mut Self {
+    pub fn expect_file_empty<P: AsRef<Utf8Path>>(&mut self, path: P) -> &mut Self {
         self.0.add_expected(path.as_ref().to_path_buf(), None);
         self
     }
@@ -230,7 +241,7 @@ impl TempTestEnv {
     /// and configure the expected end state respectively.
     pub fn run(
         setup: impl FnOnce(&mut Setup) -> &mut Setup,
-        test: impl FnOnce(&Path),
+        test: impl FnOnce(&Utf8Path),
         expect: impl FnOnce(&mut Expect) -> &mut Expect,
     ) {
         let dir = Self {
@@ -243,7 +254,7 @@ impl TempTestEnv {
         setup(&mut s);
         let Setup(dir) = s;
 
-        test(dir.root.path());
+        test(dir.root());
 
         let mut e = Expect(dir);
         expect(&mut e);
@@ -257,7 +268,10 @@ impl TempTestEnv {
     ///
     /// This is the same as [`TempTestEnv::run`], but does not check the
     /// resulting directory structure.
-    pub fn run_no_check(setup: impl FnOnce(&mut Setup) -> &mut Setup, test: impl FnOnce(&Path)) {
+    pub fn run_no_check(
+        setup: impl FnOnce(&mut Setup) -> &mut Setup,
+        test: impl FnOnce(&Utf8Path),
+    ) {
         let dir = Self {
             root: TempDir::with_prefix(TEMP_DIR_PREFIX).unwrap(),
             found: BTreeMap::new(),
@@ -268,46 +282,46 @@ impl TempTestEnv {
         setup(&mut s);
         let Setup(dir) = s;
 
-        test(dir.root.path());
+        test(dir.root());
     }
 }
 
 impl TempTestEnv {
-    fn add_expected(&mut self, expected: PathBuf, content: Option<Option<Vec<u8>>>) {
+    fn add_expected(&mut self, expected: Utf8PathBuf, content: Option<Option<Vec<u8>>>) {
         for ancestor in expected.ancestors() {
             self.expected.insert(ancestor.to_path_buf(), None);
         }
         self.expected.insert(expected, content);
     }
 
-    fn add_found(&mut self, found: PathBuf, content: Option<Vec<u8>>) {
+    fn add_found(&mut self, found: Utf8PathBuf, content: Option<Vec<u8>>) {
         for ancestor in found.ancestors() {
             self.found.insert(ancestor.to_path_buf(), None);
         }
         self.found.insert(found, content);
     }
 
-    fn read(&mut self, path: PathBuf) {
-        let rel = path.strip_prefix(self.root.path()).unwrap().to_path_buf();
+    fn read(&mut self, path: &Utf8Path) {
+        let rel = path.strip_prefix(self.root()).unwrap().to_path_buf();
         if path.metadata().unwrap().is_file() {
-            let content = std::fs::read(&path).unwrap();
+            let content = std::fs::read(path).unwrap();
             self.add_found(rel, Some(content));
         } else {
             let mut empty = true;
-            for entry in path.read_dir().unwrap() {
+            for entry in path.read_dir_utf8().unwrap() {
                 let entry = entry.unwrap();
                 self.read(entry.path());
                 empty = false;
             }
 
-            if empty && self.root.path() != path {
+            if empty && self.root() != path {
                 self.add_found(rel, None);
             }
         }
     }
 
     fn collect(&mut self) {
-        self.read(self.root.path().to_path_buf())
+        self.read(&self.root().to_path_buf())
     }
 
     fn assert(mut self) {
@@ -335,7 +349,7 @@ impl TempTestEnv {
             mismatch = true;
             writeln!(&mut msg, "\n=== Not found ===").unwrap();
             for not_found in not_found {
-                writeln!(&mut msg, "/{}", not_found.display()).unwrap();
+                writeln!(&mut msg, "/{not_found}").unwrap();
             }
         }
 
@@ -343,7 +357,7 @@ impl TempTestEnv {
             mismatch = true;
             writeln!(&mut msg, "\n=== Not expected ===").unwrap();
             for not_expected in not_expected {
-                writeln!(&mut msg, "/{}", not_expected.display()).unwrap();
+                writeln!(&mut msg, "/{not_expected}").unwrap();
             }
         }
 
@@ -351,7 +365,7 @@ impl TempTestEnv {
             mismatch = true;
             writeln!(&mut msg, "\n=== Content matched ===").unwrap();
             for (path, (found, expected)) in not_matched {
-                writeln!(&mut msg, "/{}", path.display()).unwrap();
+                writeln!(&mut msg, "/{path}").unwrap();
                 match (std::str::from_utf8(&found), std::str::from_utf8(&expected)) {
                     (Ok(found), Ok(expected)) => {
                         writeln!(&mut msg, "=== Expected ===\n>>>\n{expected}\n<<<\n").unwrap();

--- a/crates/tytanic/Cargo.toml
+++ b/crates/tytanic/Cargo.toml
@@ -28,6 +28,7 @@ tytanic-core.workspace = true
 tytanic-filter.workspace = true
 tytanic-utils.workspace = true
 
+camino = { workspace = true, features = ["serde1"] }
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive", "env", "wrap_help"] }
 clap_complete.workspace = true

--- a/crates/tytanic/src/cli/commands/mod.rs
+++ b/crates/tytanic/src/cli/commands/mod.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use camino::Utf8PathBuf;
 use chrono::DateTime;
 use chrono::Utc;
 use clap::Args;
@@ -279,7 +280,7 @@ pub struct CliArguments {
     ///
     /// If none is given, then the first ancestor with a `typst.toml` is used.
     #[arg(long, short, env = "TYPST_ROOT", global = true)]
-    pub root: Option<PathBuf>,
+    pub root: Option<Utf8PathBuf>,
 
     /// The number of threads to use for compilation.
     #[arg(long, short, global = true)]

--- a/crates/tytanic/src/cli/commands/status.rs
+++ b/crates/tytanic/src/cli/commands/status.rs
@@ -65,7 +65,7 @@ pub fn run(ctx: &mut Context, args: &Args) -> eyre::Result<()> {
         let path = path
             .strip_prefix(project.root())
             .expect("template is in project root");
-        cwrite!(bold_colored(w, Color::Cyan), "{}", path.display())?;
+        cwrite!(bold_colored(w, Color::Cyan), "{path}")?;
     } else {
         cwrite!(bold_colored(w, Color::Green), "none")?;
     }

--- a/crates/tytanic/src/cli/commands/util/manpage.rs
+++ b/crates/tytanic/src/cli/commands/util/manpage.rs
@@ -1,5 +1,4 @@
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use clap::CommandFactory;
 use color_eyre::eyre;
 
@@ -10,7 +9,7 @@ use crate::cli::Context;
 pub struct Args {
     /// The directory to write the man pages to.
     #[arg(default_value = ".")]
-    pub dir: PathBuf,
+    pub dir: Utf8PathBuf,
 }
 
 pub fn run(_ctx: &mut Context, args: &Args) -> eyre::Result<()> {

--- a/crates/tytanic/src/cli/commands/util/migrate.rs
+++ b/crates/tytanic/src/cli/commands/util/migrate.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::io::Write;
-use std::path::PathBuf;
 
+use camino::Utf8PathBuf;
 use color_eyre::eyre;
 use termcolor::Color;
 use tytanic_core::Project;
@@ -122,7 +122,7 @@ fn migrate_test_part(
     project: &Project,
     old: &Id,
     new: &Id,
-    f: fn(&Project, &Id) -> PathBuf,
+    f: fn(&Project, &Id) -> Utf8PathBuf,
 ) -> eyre::Result<()> {
     let old = f(project, old);
     let new = f(project, new);

--- a/crates/tytanic/src/cli/mod.rs
+++ b/crates/tytanic/src/cli/mod.rs
@@ -1,9 +1,9 @@
 use std::env;
 use std::io;
 use std::io::Write;
-use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 
+use camino::Utf8PathBuf;
 use color_eyre::eyre;
 use color_eyre::eyre::WrapErr;
 use commands::CompileOptions;
@@ -94,17 +94,20 @@ impl Context<'_> {
 impl Context<'_> {
     /// Resolve the current root.
     #[tracing::instrument(skip_all)]
-    pub fn root(&self) -> eyre::Result<PathBuf> {
+    pub fn root(&self) -> eyre::Result<Utf8PathBuf> {
         Ok(match &self.args.root {
             Some(root) => {
                 if !root.try_exists()? {
-                    writeln!(self.ui.error()?, "Root '{}' not found", root.display())?;
+                    writeln!(self.ui.error()?, "Root '{root}' not found")?;
                     eyre::bail!(OperationFailure);
                 }
 
-                root.canonicalize()?
+                root.canonicalize_utf8()?
             }
-            None => env::current_dir().wrap_err("reading PWD")?,
+            None => Utf8PathBuf::from_path_buf(env::current_dir().wrap_err("reading PWD")?)
+                .map_err(|non_utf8| {
+                    eyre::eyre!("can't turn '{}' into UTF-8", non_utf8.display())
+                })?,
         })
     }
 

--- a/crates/tytanic/src/json.rs
+++ b/crates/tytanic/src/json.rs
@@ -1,7 +1,6 @@
 //! Common report PODs for stable JSON representation of internal entities.
 
-use std::path::PathBuf;
-
+use camino::Utf8PathBuf;
 use serde::Serialize;
 use typst_syntax::package::PackageManifest;
 use typst_syntax::package::PackageVersion;
@@ -68,7 +67,7 @@ pub struct UnitTestJson<'t> {
     pub id: &'t str,
     pub kind: &'static str,
     pub is_skip: bool,
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
 }
 
 impl<'t> UnitTestJson<'t> {
@@ -85,7 +84,7 @@ impl<'t> UnitTestJson<'t> {
 #[derive(Debug, Serialize)]
 pub struct TemplateTestJson<'t> {
     pub id: &'t str,
-    pub path: PathBuf,
+    pub path: Utf8PathBuf,
 }
 
 impl<'t> TemplateTestJson<'t> {


### PR DESCRIPTION
While a self-contained change, the swap to UTF-8 paths is done to prepare of the new Typst release.

<!--
  Please take a look at the contributing guidelines, if you're contributing for the first time:
  https://github.com/typst-community/tytanic/blob/main/docs/CONTRIBUTING.md
-->

## Summary
<!--
  Briefly describe what this PR does. If you followed the commit guidelines you can leave this as
  is.
-->

See commit messages.

## Related Issues
<!--
  Link related issues here, even if you have done so in your commit descriptions too, this is
  primarily so GitHub auto closes the issues.

  You can do so by adding text such as "Closes #123" or "Fixes #456".

  Remove this section if there are no related issues to close.
-->

## Checklist
<!-- Check items that apply, leave those that don't. -->

- [x] I have structured my commits according to the [commit guidelines] (if applicable).
- [ ] I have added tests for new features (if applicable).
- [ ] I have updated the documentation (if applicable).

[commit guidelines]: https://github.com/typst-community/tytanic/blob/main/docs/commit-guidelines.md
