### PR TITLE
cli: Report reference optimization

### DIFF
--- a/crates/tytanic/src/cli/commands/update.rs
+++ b/crates/tytanic/src/cli/commands/update.rs
@@ -89,6 +89,16 @@ pub fn run(ctx: &mut Context, args: &Args) -> eyre::Result<()> {
         eyre::bail!(OperationFailure);
     }
 
+    let optimize_refs = args.export.optimize_refs.get_or_default();
+    if optimize_refs {
+        let mut w = ctx.ui.hint()?;
+        writeln!(w, "Optimizing references may take much longer than tt run")?;
+        writeln!(
+            w,
+            "Consider using --no-optimize-refs when using third-party hosting for references"
+        )?;
+    }
+
     let providers = ctx.providers(&project, &ctx.args.package, &ctx.args.font, &args.compile)?;
 
     let origin = match args
@@ -119,7 +129,7 @@ pub fn run(ctx: &mut Context, args: &Args) -> eyre::Result<()> {
         &providers,
         RunnerConfig {
             warnings: args.compile.warnings.into_native(),
-            optimize: args.export.optimize_refs.get_or_default(),
+            optimize: optimize_refs,
             fail_fast: args.runner.fail_fast.get_or_default(),
             // TODO: Respect bleed option.
             render_options: RenderOptions {

--- a/crates/tytanic/tests/test_cmd_update.rs
+++ b/crates/tytanic/tests/test_cmd_update.rs
@@ -5,7 +5,33 @@ fn test_update_ephemeral_to_persistent_238() {
     let env = fixture::Environment::default_package();
     let res = env.run_tytanic(["update", "--no-optimize-refs", "failing/persistent-empty"]);
 
-    // TODO: This should assert on the output in some way but we don't have
-    // reproducible test runs yet.
-    assert!(res.output().status().success());
+    // Run metadata isn't reproducible, so only assert stable output fragments.
+    assert!(res.output().status().success(), "{}", res.output());
+    assert!(
+        !res.output().stderr().contains("Optimizing references"),
+        "{}",
+        res.output()
+    );
+}
+
+#[test]
+fn test_update_reports_reference_optimization_220() {
+    let env = fixture::Environment::default_package();
+    let res = env.run_tytanic(["update", "failing/persistent-empty"]);
+
+    assert!(res.output().status().success(), "{}", res.output());
+    assert!(
+        res.output()
+            .stderr()
+            .contains("hint: Optimizing references may take much longer than tt run"),
+        "{}",
+        res.output()
+    );
+    assert!(
+        res.output().stderr().contains(
+            "Consider using --no-optimize-refs when using third-party hosting for references"
+        ),
+        "{}",
+        res.output()
+    );
 }


### PR DESCRIPTION
## Summary

- show a hint before `tt update` runs with reference optimization enabled
- point users of third-party reference hosting to `--no-optimize-refs`
- cover both the default hint and the explicit opt-out in CLI tests

## Related Issues

Closes #220

## Validation

- default and `--no-optimize-refs` CLI behavior verified manually
- `cargo test --locked -p tytanic --test test_cmd_update` — 2 passed
- `cargo test --locked --workspace --no-fail-fast` — 96 tests and 35 doctests passed
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS=-Dwarnings cargo doc --locked --workspace --no-deps`
- `cargo +1.95.0 check --locked --workspace`
- `cargo fmt --all -- --check`
- changed files checked with nightly rustfmt
- `mdbook test docs/book`
- `git diff --check`

## Checklist

- [x] I have structured my commit according to the commit guidelines.
- [x] I have added tests for the new behavior.
- [ ] I have updated the documentation (not applicable; the hint is self-describing and the issue marks docs as optional).
