### PR TITLE
core: allow configuration of system fonts

### DIFF
--- a/crates/tytanic-core/src/config.rs
+++ b/crates/tytanic-core/src/config.rs
@@ -95,6 +95,12 @@ pub struct ProjectDefaults {
     /// Defaults to `0`.
     #[serde(default = "default_max_deviations")]
     pub max_deviations: usize,
+
+    /// Whether system fonts are used by default.
+    ///
+    /// Defaults to `false`.
+    #[serde(default = "default_use_system_fonts")]
+    pub use_system_fonts: bool,
 }
 
 impl Default for ProjectDefaults {
@@ -104,6 +110,7 @@ impl Default for ProjectDefaults {
             ppi: default_ppi(),
             max_delta: default_max_delta(),
             max_deviations: default_max_deviations(),
+            use_system_fonts: default_use_system_fonts(),
         }
     }
 }
@@ -122,6 +129,10 @@ fn default_max_delta() -> u8 {
 
 fn default_max_deviations() -> usize {
     0
+}
+
+const fn default_use_system_fonts() -> bool {
+    false
 }
 
 /// The reading direction of a document.
@@ -178,5 +189,31 @@ mod tests {
 
         assert_eq!(project_config.unit_tests_root, "test_dir");
         assert_eq!(project_config.defaults.ppi, ProjectDefaults::default().ppi);
+    }
+
+    #[test]
+    fn default_use_system_fonts_is_configurable() {
+        let config = r#"
+        [package]
+        name = "testpackage"
+        version = "0.1.0"
+        entrypoint = "lib.typ"
+
+        [tool.tytanic.default]
+        use-system-fonts = true
+        "#;
+
+        let manifest = toml::from_str::<typst::syntax::package::PackageManifest>(config).unwrap();
+        let project_config = ProjectConfig::deserialize(
+            manifest
+                .tool
+                .sections
+                .get(crate::TOOL_NAME)
+                .unwrap()
+                .to_owned(),
+        )
+        .unwrap();
+
+        assert!(project_config.defaults.use_system_fonts);
     }
 }

--- a/crates/tytanic/src/cli/commands/util/fonts.rs
+++ b/crates/tytanic/src/cli/commands/util/fonts.rs
@@ -28,7 +28,8 @@ pub struct Args {
 }
 
 pub fn run(ctx: &mut Context, args: &Args) -> eyre::Result<()> {
-    let fonts = world::font_provider(&ctx.args.font);
+    let defaults = super::project_defaults(ctx)?;
+    let fonts = world::font_provider(&ctx.args.font, &defaults);
     let book = fonts.provide_font_book();
 
     let fonts = book

--- a/crates/tytanic/src/cli/commands/util/mod.rs
+++ b/crates/tytanic/src/cli/commands/util/mod.rs
@@ -1,4 +1,6 @@
 use color_eyre::eyre;
+use tytanic_core::config::ProjectDefaults;
+use tytanic_core::project::ShallowProject;
 
 use super::Context;
 
@@ -61,4 +63,13 @@ impl Command {
             Command::Vcs(args) => args.cmd.run(ctx),
         }
     }
+}
+
+fn project_defaults(ctx: &Context) -> eyre::Result<ProjectDefaults> {
+    let root = ctx.root()?;
+    let Some(project) = ShallowProject::discover(root, ctx.args.root.is_some())? else {
+        return Ok(ProjectDefaults::default());
+    };
+
+    Ok(project.load()?.config().defaults.clone())
 }

--- a/crates/tytanic/src/world.rs
+++ b/crates/tytanic/src/world.rs
@@ -36,6 +36,7 @@ use typst_syntax::package::PackageSpec;
 use tytanic_core::Project;
 use tytanic_core::TemplateTest;
 use tytanic_core::UnitTest;
+use tytanic_core::config::ProjectDefaults;
 use tytanic_core::library::augmented_default_library;
 use tytanic_core::library::augmented_library;
 use tytanic_core::world_builder::ComposedWorld;
@@ -120,18 +121,19 @@ pub fn template_file_provider(
 
 /// A font provider that provides embedded and system fonts.
 #[tracing::instrument]
-pub fn font_provider(font_opts: &FontOptions) -> Box<dyn ProvideFont> {
+pub fn font_provider(font_opts: &FontOptions, defaults: &ProjectDefaults) -> Box<dyn ProvideFont> {
     let mut store = FontStore::new();
-
     #[cfg(feature = "embedded-fonts")]
     if font_opts.use_embedded_fonts.get_or_default() {
         store.extend(fonts::embedded());
     }
-
-    if font_opts.use_system_fonts.get_or_default() {
+    if font_opts
+        .use_system_fonts
+        .get()
+        .unwrap_or(defaults.use_system_fonts)
+    {
         store.extend(fonts::system());
     }
-
     store.extend(
         font_opts
             .font_paths
@@ -139,7 +141,6 @@ pub fn font_provider(font_opts: &FontOptions) -> Box<dyn ProvideFont> {
             .map(PathBuf::as_path)
             .flat_map(fonts::scan),
     );
-
     tracing::debug!(fonts = ?store.book().families().count(), "collected font families");
     Box::new(store)
 }
@@ -238,7 +239,7 @@ impl Providers {
                     .is_some()
                     .then(|| template_file_provider(project, package_opts))
             }),
-            fonts: font_provider(font_opts),
+            fonts: font_provider(font_opts, &project.config().defaults),
             datetime: datetime_provider(compile_opts)?,
         })
     }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Highlights
 
 ## Changes
+- Set the use of system fonts in the configuration file and not only as a CLI flag
 
 ## Fixes
 

--- a/docs/book/src/reference/config.md
+++ b/docs/book/src/reference/config.md
@@ -11,6 +11,10 @@ The project config is specified in the `typst.toml` manifest under the `tool.tyt
 |`default.ppi`|`144.0`|Sets the default pixel per inch used for exporting and comparing documents, expects a floating point value as an argument. Can be overridden per test using an annotation.|
 |`default.max-delta`|`1`|Sets the default maximum allowed per-pixel delta, expects an integer between 0 and 255 as an argument. Can be overridden per test using an annotation.|
 |`default.max-deviations`|`0`|Sets the default maximum allowed deviations, expects an integer as an argument. Can be overridden per test using an annotation.|
+|`default.use-system-fonts`|`false`|Sets whether system fonts are used by default. Can be overridden using `--use-system-fonts` or `--no-use-system-fonts`.|
+
+> [!WARNING]
+> Even small font version variations can create sub-pixel differences that will be very hard to debug. Only use the system fonts if you are certain your environment is completely reproducible to all contributors.
 
 ## System Config
 There are currently no system config options and the config is not yet loaded.


### PR DESCRIPTION
## Summary

This change adds a key to the project defaults configuration section, allowing to configure the loading of system fonts like the current cli flag `--[no-]allow-system-fonts`. The cli flag has priority over the configuration file.

## Related Issues

This is loosely related to #197: it doesn't allow setting this per-test but it is useful to have this per-project as a first step (we have different in-house packages with different requirements at $work).

## Checklist

- [x] I have structured my commits according to the [commit guidelines] (if applicable).
- [x] I have added tests for new features (if applicable).
- [x] I have updated the documentation (if applicable).
