### PR TITLE
flake: Use empty string for RUSTFLAGS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,7 @@
               # Upstream defaults to lld on x86_64-unknown-linux-gnu, we need to use the system linker
               "-Clinker-features=-lld -Clink-self-contained=-linker"
             else
-              null;
+              ""; # Don't use null here, otherwise the cachix option explodes.
 
           # Crane-based Nix flake configuration.
           # Based on https://github.com/ipetkov/crane/blob/master/examples/trunk-workspace/flake.nix


### PR DESCRIPTION
The derivation for the cachix CD action seems to require `RUSTFLAGS`, or any environment variable to be non-null. I'm unsure if tyhe empty string works the same for the flake, though. It should be fine though, since an empty environment variable should be treated like an unset one by rustc.

The cachix action was taken from helix, which always has RUSTFLAGS set in its flake, so we can't really use that as an example.

<!--
  Please take a look at the contributing guidelines, if you're contributing for the first time:
  https://github.com/typst-community/tytanic/blob/main/docs/CONTRIBUTING.md
-->

## Summary
<!--
  Briefly describe what this PR does. If you followed the commit guidelines you can leave this as
  is.
-->

See commit messages.

## Related Issues
<!--
  Link related issues here, even if you have done so in your commit descriptions too, this is
  primarily so GitHub auto closes the issues.

  You can do so by adding text such as "Closes #123" or "Fixes #456".

  Remove this section if there are no related issues to close.
-->

## Checklist
<!-- Check items that apply, leave those that don't. -->

- [x] I have structured my commits according to the [commit guidelines] (if applicable).
- [ ] I have added tests for new features (if applicable).
- [ ] I have updated the documentation (if applicable).

[commit guidelines]: https://github.com/typst-community/tytanic/blob/main/docs/commit-guidelines.md
